### PR TITLE
add logging; fix JSON-RPC request ID issue

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -142,7 +142,10 @@ func TestServerIntegration(t *testing.T) {
 			Jsonrpc: "2.0",
 			Method:  method,
 			Params:  json.RawMessage(paramsBytes),
-			Id:      transport.RequestId(i),
+			Id: transport.RequestId{
+				StringValue: fmt.Sprintf("%d", i),
+				IsString:    true,
+			},
 		}
 		i++
 
@@ -193,7 +196,7 @@ func TestServerIntegration(t *testing.T) {
 		"capabilities": map[string]interface{}{},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, float64(1), resp["id"])
+	assert.Equal(t, "1", resp["id"])
 	assert.NotNil(t, resp["result"])
 
 	time.Sleep(100 * time.Millisecond)

--- a/transport/http/gin.go
+++ b/transport/http/gin.go
@@ -29,10 +29,10 @@ func (t *GinTransport) Start(ctx context.Context) error {
 
 // Send implements Transport.Send
 func (t *GinTransport) Send(ctx context.Context, message *transport.BaseJsonRpcMessage) error {
-	key := message.JsonRpcResponse.Id
-	responseChannel := t.responseMap[int64(key)]
+	key := message.JsonRpcResponse.Id.String()
+	responseChannel := t.responseMap[key]
 	if responseChannel == nil {
-		return fmt.Errorf("no response channel found for key: %d", key)
+		return fmt.Errorf("no response channel found for key: %s", key)
 	}
 	responseChannel <- message
 	return nil

--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -52,22 +52,22 @@ func (t *HTTPTransport) Start(ctx context.Context) error {
 
 // Send implements Transport.Send
 func (t *HTTPTransport) Send(ctx context.Context, message *transport.BaseJsonRpcMessage) error {
-	key := message.JsonRpcResponse.Id
-	fmt.Printf("[Send] Attempting to send response with key: %d\n", key)
+	key := message.JsonRpcResponse.Id.String()
+	fmt.Printf("[Send] Attempting to send response with key: %s\n", key)
 
-	responseChannel := t.baseTransport.responseMap[int64(key)]
+	responseChannel := t.baseTransport.responseMap[key]
 	if responseChannel == nil {
 		fmt.Printf("[Send] Response map keys: %v\n", t.getResponseMapKeys())
 
-		return fmt.Errorf("no response channel found for key: %d", key)
+		return fmt.Errorf("no response channel found for key: %s", key)
 	}
 	responseChannel <- message
 	return nil
 }
 
 // Helper method to get keys
-func (t *HTTPTransport) getResponseMapKeys() []int64 {
-	keys := make([]int64, 0, len(t.baseTransport.responseMap))
+func (t *HTTPTransport) getResponseMapKeys() []string {
+	keys := make([]string, 0, len(t.baseTransport.responseMap))
 	for k := range t.baseTransport.responseMap {
 		keys = append(keys, k)
 	}


### PR DESCRIPTION
This was done with huge help from Cursor and Claude Sonnet-3.7. Many thanks to them!

The core issue we discovered is that the original implementation assumed JSON-RPC IDs could only be integers, while the JSON-RPC 2.0 specification clearly states that IDs can be strings, numbers, or null (though null is typically used only for notifications).

Here's a concise summary of the essential changes needed to make the implementation compliant with the JSON-RPC 2.0 specification regarding request IDs:

1. **Update the `RequestId` struct** to properly handle both string and numeric IDs:
   ```go
   type RequestId struct {
       StringValue string
       NumberValue int64
       IsString    bool
   }
   ```

2. **Implement custom JSON marshaling/unmarshaling** for the `RequestId` type:
   - `UnmarshalJSON`: Try to unmarshal as string first, then as number
   - `MarshalJSON`: Marshal as string or number based on the `IsString` flag
   - `String()`: Return a string representation regardless of the underlying type

3. **Update map keys** in various places to use string representations of IDs instead of raw integers:
   - Change `map[int64]chan *transport.BaseJsonRpcMessage` to `map[string]chan *transport.BaseJsonRpcMessage`
   - Use `Id.String()` as the key instead of type-casting to `int64`

4. **Modify the request ID generation** in the Protocol implementation:
   - Use a counter that gets converted to a string-based RequestId
   - Ensure all ID comparisons and lookups use the string representation

5. **Update test assertions** to expect string IDs where appropriate

These changes maintain backward compatibility while adding support for string IDs, making the implementation fully compliant with the JSON-RPC 2.0 specification.

The key insight is that the JSON-RPC spec allows flexibility in ID types, and implementations should handle this properly to ensure interoperability with other JSON-RPC clients and servers.

---
To discover that, we had to add extensive logging to the original code, and I decided to keep it there. To enable logging, you should create the server with `WithLogFile()` and specify the file path like this:

```go
		server = mcp.NewServer(transport,
			mcp.WithName("my-mcp-server"),
			mcp.WithVersion("1.0.0"),
			mcp.WithLogFile("/tmp/my-mcp.log"))
```

Without this function, the server will not produce any logs. Note that we can't use logging to stdout because it's redirected to the client.
